### PR TITLE
update installation min nodejs version to latest lts

### DIFF
--- a/guide/install.md
+++ b/guide/install.md
@@ -2,7 +2,7 @@
 
 ## Starter Template
 
-> Slidev requires [**Node.js >=14.0**](https://nodejs.org/)
+> Slidev requires [**Node.js >=14.7**](https://nodejs.org/)
 
 The best way to get started is using our official starter template.
 

--- a/guide/install.md
+++ b/guide/install.md
@@ -29,11 +29,9 @@ If you still prefer to install Slidev manually or would like to integrate it int
 ```bash
 $ npm install @slidev/cli @slidev/theme-default
 ```
-
 ```bash
 $ touch slides.md
 ```
-
 ```bash
 $ npx slidev
 ```

--- a/guide/install.md
+++ b/guide/install.md
@@ -2,7 +2,7 @@
 
 ## Starter Template
 
-> Slidev requires [**Node.js >=14.7**](https://nodejs.org/)
+> Slidev requires [**Node.js >=14.17**](https://nodejs.org/)
 
 The best way to get started is using our official starter template.
 
@@ -29,9 +29,11 @@ If you still prefer to install Slidev manually or would like to integrate it int
 ```bash
 $ npm install @slidev/cli @slidev/theme-default
 ```
+
 ```bash
 $ touch slides.md
 ```
+
 ```bash
 $ npx slidev
 ```


### PR DESCRIPTION
see Issue #182 where this was found https://github.com/slidevjs/slidev/issues/182
thinking about this a bit more though, if there's a problem with the node.js 14.2 build process maybe saying `>=14.17` isn't right either 🤔 - perhaps instead it should say something regarding LTS?