### PR TITLE
docs: fix typo

### DIFF
--- a/guide/faq.md
+++ b/guide/faq.md
@@ -122,7 +122,7 @@ canvasWidth: 800
 We provide a built-in component `<Transform />`, which is a thin wrapper of CSS transform property.
 
 ```md
-<Tranform :scale="1.4">
+<Transform :scale="1.4">
 
 - Item 1
 - Item 2

--- a/guide/syntax.md
+++ b/guide/syntax.md
@@ -257,7 +257,7 @@ This shows on the left
 
 This shows on the right
 
-<template>
+</template>
 ```
 
 <div class="grid grid-cols-2 rounded border border-gray-400 border-opacity-50 px-10 pb-4">


### PR DESCRIPTION
Fixed typos in `<template>` and `<Transform>` tags.