### PR TITLE
docs: Fix typo (#26)

### DIFF
--- a/custom/fonts.md
+++ b/custom/fonts.md
@@ -4,7 +4,7 @@
 
 While you can use HTML and CSS to custom the fonts and style for your slides as you want, Slidev also provides a convenient way to use them effortlessly.
 
-In your fontmatter, configure as following
+In your frontmatter, configure as following
 
 ```yaml
 ---

--- a/guide/faq.md
+++ b/guide/faq.md
@@ -21,7 +21,7 @@ The second column
 </div>
 ```
 
-Go further, you can customize the size of each columns like:
+Go further, you can customize the size of each column like:
 
 ```html
 <div class="grid grid-cols-[200px,1fr,10%] gap-4">

--- a/guide/syntax.md
+++ b/guide/syntax.md
@@ -369,7 +369,7 @@ Learn more: [Demo](https://sli.dev/demo/starter/8) | [KaTeX](https://katex.org/)
 
 You can also create diagrams / graphs from textual descriptions in your Markdown, powered by [Mermaid](https://mermaid-js.github.io/mermaid).
 
-Code blocks marked as `mermaid` will be converted to digrams, for example:
+Code blocks marked as `mermaid` will be converted to diagrams, for example:
 
 ~~~md
 //```mermaid


### PR DESCRIPTION
Fix https://github.com/slidevjs/docs/issues/26 and some other typos:

- "fontmatter" to "frontmatter";
- "columns" to "column"
- "digrams" to "diagrams"