### PR TITLE
docs: add favicon frontmatter configure

### DIFF
--- a/custom/index.md
+++ b/custom/index.md
@@ -33,6 +33,8 @@ aspectRatio: '16/9'
 # real width of the canvas, unit in px
 canvasWidth: 980
 
+# favicon, can be a local file path or URL
+favicon: 'https://cdn.jsdelivr.net/gh/slidevjs/slidev/assets/favicon.png'
 # fonts will be auto imported from Google fonts
 # Learn more: https://sli.dev/custom/fonts
 fonts:


### PR DESCRIPTION
slidevjs/slidev#421 added the possibility to configure a favicon. Currently, the [docs](https://sli.dev/custom/#frontmatter-configures) lack documentation about this.