### PR TITLE
feat: update install.md to fix the missed docker part

### DIFF
--- a/guide/install.md
+++ b/guide/install.md
@@ -62,6 +62,67 @@ This command will also try to use local `@slidev/cli` if it has been found in th
 
 ## Install on Docker
 
-If you need a rapid way to run a presentation with containers, you can use the prebuilt [docker](https://hub.docker.com/r/stig124/slidev) image maintained by [stig124](https://github.com/Stig124), or build your own.
+If you need a rapid way to run a presentation with containers, you can use the prebuilt [docker](https://hub.docker.com/r/tangramor/slidev) image maintained by [tangramor](https://github.com/tangramor), or build your own.
 
-Refer to the [slidevjs/container repo](https://github.com/slidevjs/container) for more details.
+Just run following command in your work folder:
+
+```bash
+docker run --name slidev --rm -it \
+    --user node \
+    -v ${PWD}:/slidev \
+    -p 3030:3030 \
+    tangramor/slidev:latest
+```
+
+If your work folder is empty, it will generate a template `slides.md` and other related files under your work folder, and launch the server on port `3030`. 
+
+You can access your slides from http://localhost:3030/
+
+
+### Build deployable image
+
+Or you can create your own slidev project to a docker image with Dockerfile:
+
+```Dockerfile
+FROM tangramor/slidev:latest
+
+ADD . /slidev
+
+```
+
+Create the docker image: `docker build -t myppt .`
+
+And run the container: `docker run --name myslides --rm --user node -p 3030:3030 myppt`
+
+You can visit your slides from http://localhost:3030/
+
+
+### Build hostable SPA (Single Page Application)
+
+Run command `docker exec -i slidev npx slidev build` on the running container `slidev`. It will generate static HTML files under `dist` folder.
+
+You can host `dist` in a static web site such as [Github pages](https://tangramor.github.io/slidev_docker/) or Gitlab pages. Because in Github pages the url may contain subfolder, so you need to modify the generated `index.html` to change `href="/assets/xxx` to `href="./assets/xxx`. And to avoid Jekyll build process, you need to add an empty file `.nojekyll`.
+
+You can also host it by yourself:
+
+```bash
+docker run --name myslides --rm -p 80:80 -v ${PWD}/dist:/usr/share/nginx/html nginx:alpine
+```
+
+Or create a static image with following Dockerfile:
+
+```Dockerfile
+FROM nginx:alpine
+
+COPY dist /usr/share/nginx/html
+
+```
+
+Create the docker image: `docker build -t mystaticppt .`
+
+And run the container: `docker run --name myslides --rm -p 80:80 mystaticppt`
+
+You can visit your slids from http://localhost/
+
+
+Refer to the [tangramor/slidev_docker](https://github.com/tangramor/slidev_docker) for more details.


### PR DESCRIPTION
The old docker image cannot be found on docker hub any more. I created a new one and add more instructions about how to use it.