### PR TITLE
docs: add mention to --dark option when exporting

### DIFF
--- a/guide/exporting.md
+++ b/guide/exporting.md
@@ -19,6 +19,12 @@ $ slidev export
 
 After a few seconds, your slides will be ready at `./slides-exports.pdf`.
 
+In case you want to export your slides using the dark version of the theme, use the `--dark` option:
+
+```bash
+$ slidev export --dark
+```
+
 ### Export Clicks Steps
 
 > Available since v0.21


### PR DESCRIPTION
I wanted to export my slides using the dark version of the theme and it took me a while to find this option, I would really appreciate having it right next to the instructions on how to export, specially given the popularity of dark mode these days 😊 

This commit just adds a mention to using the `--dark` option when exporting the slides.