### PR TITLE
docs: make it clear why the global files might not render

### DIFF
--- a/custom/global-layers.md
+++ b/custom/global-layers.md
@@ -25,6 +25,9 @@ Layers relationship:
 
 The text `Your Name` will appear to all your slides.
 
+> **Note:**
+> If Slidev is currently running in the background, then you will need to restart it in order to pick up on the new global file that was added.
+
 ```html
 <!-- custom-nav-controls -->
 <template>


### PR DESCRIPTION
This explains how to resolve a potential issue where a user might add the `global-bottom.vue` or other global files, with Slidev currently running a presentation (such as using `npm run dev`), but not see anything rendered in the browser window.