### PR TITLE
docs: markdown code highlighting for none of the lines

### DIFF
--- a/guide/syntax.md
+++ b/guide/syntax.md
@@ -102,6 +102,19 @@ function add(
 //```
 ~~~
 
+To skip highlighting any lines, you can set the line number to `0`. For example
+
+~~~ts {0}
+//```ts {0}
+function add(
+  a: Ref<number> | number,
+  b: Ref<number> | number
+) {
+  return computed(() => unref(a) + unref(b))
+}
+//```
+~~~
+
 This will first highlight `a: Ref<number> | number` and `b: Ref<number> | number`, and then `return computed(() => unref(a) + unref(b))` after one click, and lastly, the whole block. Learn more in the [clicks animations guide](/guide/animations).
 
 ### Monaco Editor


### PR DESCRIPTION
This was an easy first guess of just supplying the line number 0 to make it skip highlighting any lines (imagine you want to display several code blocks and don't want that other code blocks draw the audience attention)