### PR TITLE
docs: update custom keybindings

### DIFF
--- a/custom/config-shortcuts.md
+++ b/custom/config-shortcuts.md
@@ -29,4 +29,20 @@ With the setup, you can provide the custom setting for shortcuts mentioned in [N
 
 The configuration function receives an object with some navigation methods, and returns an array containing some shortcut configuration. Refer to the type definitions for more details.
 
+The `key` type only allows for strings, but you can still bind multiple keys by using following convention:
+
+```ts
+import { defineShortcutsSetup, NavOperations } from '@slidev/types'
+
+export default defineShortcutsSetup((nav: NavOperations) => {
+  return [
+    {
+      key: 'ShiftLeft+ArrowRight',
+      fn: () => nav.next(),
+      autoRepeat: true,
+    }
+  ]
+})
+```
+
 Refer to [useMagicKeys | VueUse](https://vueuse.org/core/useMagicKeys/) for more details about key pressed event.


### PR DESCRIPTION
The docs were missing how to bind shortcuts to multiple keys together.