### PR TITLE
docs: update for advanced navigation features

### DIFF
--- a/custom/config-shortcuts.md
+++ b/custom/config-shortcuts.md
@@ -4,6 +4,8 @@
 
 <Environment type="client" />
 
+## Getting started
+
 Create `./setup/shortcuts.ts` with the following content:
 
 ```ts
@@ -29,6 +31,8 @@ With the setup, you can provide the custom setting for shortcuts mentioned in [N
 
 The configuration function receives an object with some navigation methods, and returns an array containing some shortcut configuration. Refer to the type definitions for more details.
 
+## Advanced key binding
+
 The `key` type only allows for strings, but you can still bind multiple keys by using following convention:
 
 ```ts
@@ -39,6 +43,28 @@ export default defineShortcutsSetup((nav: NavOperations) => {
     {
       key: 'ShiftLeft+ArrowRight',
       fn: () => nav.next(),
+      autoRepeat: true,
+    }
+  ]
+})
+```
+
+## Advanced navigation features
+
+The `nav` navigation operations allows you to access some functionalities than basic _next slide_ or _previous slide_. See the following for use-cases:
+
+```ts
+import { defineShortcutsSetup, NavOperations } from '@slidev/types'
+
+export default defineShortcutsSetup((nav: NavOperations) => {
+  return [
+    {
+      key: 'e',
+      
+      // Set the `e` keyboard shortcut to be used as a bookmark
+      // or quick-access of sorts, to navigate specifically to
+      // slide number 42
+      fn: () => nav.go(42),
       autoRepeat: true,
     }
   ]


### PR DESCRIPTION
This documentation update follows new feature from https://github.com/slidevjs/slidev/pull/631
and specifically addresses:
1. Up-to-date documentation with regards to navigation features exposed to custom shortcut bindings
2. Tidy-up this page with header breaks

Note: don't merge until we have a new version released with passing tests. Seems like 0.33.1 [has a failing Cypress test](https://github.com/slidevjs/slidev/runs/6955808143?check_suite_focus=true).