### PR TITLE
feat: add copy code button

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -297,4 +297,16 @@ module.exports = {
       '/': slidebars,
     },
   },
+  markdown: {
+    config: (md) => {
+      md.use(md_ => {
+        const fence = md_.renderer.rules.fence
+        if (fence)
+          md_.renderer.rules.fence = (...args) => {
+            const rawCode = fence(...args)
+            return `<div class="languages-box"><span class="copy">copy</span>${rawCode}</div>`
+          }
+      })
+    },
+  },
 }

--- a/.vitepress/theme/Layout.vue
+++ b/.vitepress/theme/Layout.vue
@@ -56,13 +56,14 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, defineAsyncComponent } from 'vue'
+import { ref, computed, watch, defineAsyncComponent, nextTick } from 'vue'
 import {
   useRoute,
   useSiteData,
   useSiteDataByRoute,
 } from 'vitepress'
 import type { DefaultTheme } from './config'
+import { useCopyCode } from './composables/copy-code'
 
 // components
 import NavBar from './components/NavBar.vue'
@@ -79,6 +80,13 @@ const theme = computed(() => siteData.value.themeConfig)
 const AlgoliaSearchBox = defineAsyncComponent(
   () => import('./components/AlgoliaSearchBox.vue'),
 )
+
+// reload window after init
+nextTick(useCopyCode)
+// route change after init
+watch(() => route.path, () => {
+  nextTick(useCopyCode)
+})
 
 // custom layout
 const isCustomLayout = computed(() => !!route.data.frontmatter.customLayout)

--- a/.vitepress/theme/composables/copy-code.ts
+++ b/.vitepress/theme/composables/copy-code.ts
@@ -1,0 +1,79 @@
+import { inBrowser } from 'vitepress'
+
+export function useCopyCode(ppp: Object) {
+  if (inBrowser)
+    document
+    .querySelectorAll<HTMLElement>(
+        '.languages-box>.copy'
+    )
+    .forEach(handleElement)
+}
+
+async function copyToClipboard(text: string) {
+  try {
+    return navigator.clipboard.writeText(text)
+  } catch {
+    const element = document.createElement('textarea')
+    const previouslyFocusedElement = document.activeElement
+
+    element.value = text
+
+    // Prevent keyboard from showing on mobile
+    element.setAttribute('readonly', '')
+
+    element.style.contain = 'strict'
+    element.style.position = 'absolute'
+    element.style.left = '-9999px'
+    element.style.fontSize = '12pt' // Prevent zooming on iOS
+
+    const selection = document.getSelection()
+    const originalRange = selection
+      ? selection.rangeCount > 0 && selection.getRangeAt(0)
+      : null
+
+    document.body.appendChild(element)
+    element.select()
+
+    // Explicit selection workaround for iOS
+    element.selectionStart = 0
+    element.selectionEnd = text.length
+
+    document.execCommand('copy')
+    document.body.removeChild(element)
+
+    if (originalRange) {
+      selection!.removeAllRanges() // originalRange can't be truthy when selection is falsy
+      selection!.addRange(originalRange)
+    }
+
+    // Get the focus back on the previously focused element, if any
+    if (previouslyFocusedElement) {
+      ;(previouslyFocusedElement as HTMLElement).focus()
+    }
+  }
+}
+
+function handleElement(el: HTMLElement) {
+  el.onclick = () => {
+    const parent = <HTMLElement>el.nextElementSibling
+
+    if (!parent) return
+
+    const isShell =
+      parent.classList.contains('language-sh') ||
+      parent.classList.contains('language-bash')
+
+    let { innerText: text = '' } = parent
+
+    if (isShell) {
+      text = text.replace(/^ *\$ /gm, '')
+    }
+
+    copyToClipboard(text).then(() => {
+      el.classList.add('copied')
+      setTimeout(() => {
+        el.classList.remove('copied')
+      }, 3000)
+    })
+  }
+}

--- a/.vitepress/theme/styles/code.css
+++ b/.vitepress/theme/styles/code.css
@@ -94,6 +94,39 @@ div[class*='language-'] code {
   font-family: var(--prism-font-family);
 }
 
+.languages-box {
+    position: relative;
+}
+
+.languages-box:hover .copy {
+    opacity: 1;
+}
+
+.languages-box .copy {
+    opacity: 0;
+    position: absolute;
+    top: 10px;
+    right: 0.8em;
+    height: 30px;
+    z-index: 1;
+    cursor: pointer;
+    transition: 0.2s;
+    border-radius: 4px;
+    font-size: 12px;
+    font-weight: bold;
+    line-height: 30px;
+    text-align: center;
+    padding: 0 5px;
+}
+
+.languages-box .copy:hover {
+    background-color: var(--c-bg-secondary);
+}
+
+.languages-box .copied {
+    color: #009600;
+}
+
 .token.important {
   font-weight: normal;
 }


### PR DESCRIPTION
I noticed can now be copied the code in the `vitepress v1.0.0` docs. I think that's great so i added support for `slidevjs`.
I don't think my code is the best, Check my code and give me some tips please, Thanks!

Example:
<img width="964" alt="image" src="https://user-images.githubusercontent.com/50652358/177829688-241589bb-0a35-421b-ba35-e9ea6c15b4e0.png">
