### PR TITLE
fix(mermaid): remove slashes

### DIFF
--- a/guide/syntax.md
+++ b/guide/syntax.md
@@ -401,22 +401,22 @@ You can also create diagrams / graphs from textual descriptions in your Markdown
 Code blocks marked as `mermaid` will be converted to diagrams, for example:
 
 ~~~md
-//```mermaid
+```mermaid
 sequenceDiagram
   Alice->John: Hello John, how are you?
   Note over Alice,John: A typical interaction
-//```
+```
 ~~~
 
 You can further pass an options object to it to specify the scaling and theming. The syntax of the object is a JavaScript object literal, you will need to add quotes (`'`) for strings and use comma (`,`) between keys.
 
 ~~~md
-//```mermaid {theme: 'neutral', scale: 0.8}
+```mermaid {theme: 'neutral', scale: 0.8}
 graph TD
 B[Text] --> C{Decision}
 C -->|One| D[Result 1]
 C -->|Two| E[Result 2]
-//```
+```
 ~~~
 
 Learn more: [Demo](https://sli.dev/demo/starter/9) | [Mermaid](https://mermaid-js.github.io/mermaid)


### PR DESCRIPTION
The reader could think that //```mermaid is the real syntax but it is ```mermaid