### PR TITLE
docs: fix exportFilename

### DIFF
--- a/custom/index.md
+++ b/custom/index.md
@@ -21,7 +21,7 @@ info: false
 # enabled pdf downloading in SPA build, can also be a custom url
 download: false
 # filename of the export file
-exportFilename: 'slidev-exported.pdf'
+exportFilename: 'slidev-exported'
 # syntax highlighter, can be 'prism' or 'shiki'
 highlighter: 'prism'
 # show line numbers in code blocks


### PR DESCRIPTION
Adding the `.pdf` extension to the `exportFilename` property in the fontmatter is _incorrect_

The `.pdf` extension is appended to the filename in [this part of the code](https://github.com/slidevjs/slidev/blob/main/packages/client/logic/nav.ts#L172)

Leaving this in the docs will cause confusion