### PR TITLE
docs(search): correct credentials for docsearch

### DIFF
--- a/.vitepress/config.js
+++ b/.vitepress/config.js
@@ -252,7 +252,8 @@ module.exports = {
     editLinkText: 'Suggest changes to this page',
 
     algolia: {
-      apiKey: '1a5c5a504139c58f428974c78c55291d',
+      appId: 'LCBV6MIFS6',
+      apiKey: '1ff173fe73b20edc962c1c24c0b1c160',
       indexName: 'slidev',
       searchParameters: {
         // for translations maintainers: change the filter to your locale code (subdomain name)


### PR DESCRIPTION
Not 100% sure if the index name and filters are right, but it's a v3 config, so requires appId