### PR TITLE
docs: add documentation for export range feature Fix #821

### DIFF
--- a/guide/exporting.md
+++ b/guide/exporting.md
@@ -45,6 +45,17 @@ When passing in the `--format png` option, Slidev will export PNG images for eac
 $ slidev export --format png
 ```
 
+### Export a range of slides
+
+By default, all slides in the presentation are exported. If you want to export a specific slide or a range of slides you can set the `--range` option and specify which slides you would like to export. 
+
+```bash
+$ slidev export --range 1,6-8,10
+```
+
+This option accepts both specific slide numbers and ranges.
+
+The example above would export slides 1,6,7,8, and 10. 
 
 ## Presenter notes
 

--- a/guide/exporting.md
+++ b/guide/exporting.md
@@ -45,9 +45,6 @@ When passing in the `--format png` option, Slidev will export PNG images for eac
 $ slidev export --format png
 ```
 
-### Single-Page Application (SPA)
-
-See [Static Hosting](/guide/hosting).
 
 ## Presenter notes
 
@@ -58,3 +55,7 @@ Export only the presenter notes (the last comment block for each slide) into a t
 ```bash
 $ slidev export-notes
 ```
+
+## Single-Page Application (SPA)
+
+See [Static Hosting](/guide/hosting).


### PR DESCRIPTION
This PR:
* adds the documentation for the `range` option under the `export` function
* moves the "SPA export" to it's own heading 2 document section 

It turns out, the `range` functionality was already in the code base, however the documentation was missing. 

I took a crack at writing something that would be helpful, but honestly I'm not an English major so it's possible that this could be written a lot better. 

Happy to change / enhance / and looking forward to feedback on how to improve. 

Thanks.