### PR TITLE
docs: fix broken link in faq

### DIFF
--- a/guide/faq.md
+++ b/guide/faq.md
@@ -43,7 +43,7 @@ The third column (10% width to parent container)
 </div>
 ```
 
-Learn more about [Windi CSS Grids](https://windicss.org/utilities/grid.html).
+Learn more about [Windi CSS Grids](https://windicss.org/utilities/layout/grid.html).
 
 ## Positioning
 


### PR DESCRIPTION
Windi docs for grid now live under /utilities/layout/grid instead of just /utilities/grid