### PR TITLE
docs: fix typo in builtin slide transitions

### DIFF
--- a/guide/animations.md
+++ b/guide/animations.md
@@ -220,8 +220,8 @@ This will give you a nice sliding effects on slide switching. Setting it in the 
 - `fade-out` - Fade out and then fade in
 - `slide-left` - Slides to the left (slide to right when going backward)
 - `slide-right` - Slides to the right (slide to left when going backward)
-- `slide-top` - Slides to the top (slide to bottom when going backward)
-- `slide-bottom` - Slides to the bottom (slide to top when going backward)
+- `slide-up` - Slides to the top (slide to bottom when going backward)
+- `slide-down` - Slides to the bottom (slide to top when going backward)
 
 ### Custom Transitions
 


### PR DESCRIPTION
```
export type BuiltinSlideTransition = 'slide-up' | 'slide-down' | 'slide-left' | 'slide-right' | 'fade' | 'zoom' | 'none'
```

ref https://github.com/slidevjs/slidev/blob/4ac00702da4c3bec521fe8725f596a8eb42d5b23/packages/types/src/config.ts#L306