### PR TITLE
docs: fix typo in output directory

### DIFF
--- a/guide/hosting.md
+++ b/guide/hosting.md
@@ -61,7 +61,7 @@ When using the download option, you can also provide the export options:
 You can change the output directory using `--out`.
 
 ```bash
-$ slidev build --dir my-build-folder
+$ slidev build --out my-build-folder
 ```
 
 ### Watch mode


### PR DESCRIPTION
Just a small typo.