### PR TITLE
docs: grids-cols to grid-cols

### DIFF
--- a/custom/config-windicss.md
+++ b/custom/config-windicss.md
@@ -7,7 +7,7 @@ Markdown naturally supports embedded HTML markups. You can therefore style your 
 For example:
 
 ```html
-<div class="grid pt-4 gap-4 grids-cols-[100px,1fr]">
+<div class="grid pt-4 gap-4 grid-cols-[100px,1fr]">
 
 ### Name
 


### PR DESCRIPTION
windicss repo doesn't have `grids-col` but I do find `grid-cols` but please check my sanity as I can't get either to work with the example that uses arbitrary values. Possibly related: https://github.com/slidevjs/slidev/issues/938