### PR TITLE
docs: align theme docs with types

### DIFF
--- a/themes/write-a-theme.md
+++ b/themes/write-a-theme.md
@@ -64,7 +64,7 @@ A theme can provide default [configurations](/custom/#frontmatter-configures) vi
 // package.json
 {
   "slidev": {
-    "default": {
+    "defaults": {
       "aspectRatio": "16/9",
       "canvasWidth": 980,
       "fonts": {
@@ -128,7 +128,7 @@ Also, remember to specify the supported highlighters in your `package.json`
 // package.json
 {
   "slidev": {
-    "highlighter": "shiki" // or "prism" or "all"
+    "highlighter": "shiki" // or "prism" or "both"
   }
 }
 ```


### PR DESCRIPTION
Align examples in `write-a-theme.md` with the following typedefs:

```ts
/**
 * Metadata for "slidev" field in themes' package.json
 */
export interface SlidevThemeMeta {
  defaults?: Partial<SlidevConfig>
  colorSchema?: 'dark' | 'light' | 'both'
  highlighter?: 'prism' | 'shiki' | 'both'
}
```
[(source)](https://github.com/slidevjs/slidev/blob/d34da0c84ec48d510902aa913258b06018ca7697/packages/types/src/types.ts#L31C1-L35)

Although 'all' works too as a value for `highlighter`, it makes sense to change it for continuity's sake.