### PR TITLE
docs: fix incorrect option name

### DIFF
--- a/guide/install.md
+++ b/guide/install.md
@@ -202,7 +202,7 @@ Export slides to PDF (or other format).
 Options:
 
 * `--output` (`string`, default: use `exportFilename` (see https://sli.dev/custom/#frontmatter-configures) or use `[entry]-export`): path to the output.
-* `--base` (`'pdf', 'png', 'md'`, default: `'pdf'`): output format.
+* `--format` (`'pdf', 'png', 'md'`, default: `'pdf'`): output format.
 * `--timeout` (`number`, default: `30000`): timeout for rendering the print page (see https://playwright.dev/docs/api/class-page#page-goto).
 * `--range` (`string`): page ranges to export (example: `'1,4-5,6'`).
 * `--dark` (`boolean`, default: `false`): export as dark theme.


### PR DESCRIPTION
To specify output format, use `--format`, not `--base`.