### PR TITLE
fix: ipa correction

### DIFF
--- a/guide/index.md
+++ b/guide/index.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Slidev <sup>(slide + dev, **/slʌɪdɪv/**)</sup> is a web-based slides maker and presenter. It's designed for developers to focus on writing content in Markdown while also having the power of HTML and Vue components to deliver pixel-perfect layouts and designs with embedded interactive demos in your presentations.
+Slidev <sup>(slide + dev, **/slaɪdɪv/**)</sup> is a web-based slides maker and presenter. It's designed for developers to focus on writing content in Markdown while also having the power of HTML and Vue components to deliver pixel-perfect layouts and designs with embedded interactive demos in your presentations.
 
 It uses a feature-rich markdown file to generate beautiful slides with an instant reloading experience, along with many built-in integrations such as live coding, PDF exporting, presentation recording, and so on. Since it's powered by the web, you can do anything with Slidev - the possibilities are endless.
 


### PR DESCRIPTION
according to [wiktionary](https://en.wiktionary.org/wiki/slide#Pronunciation) the vowel in `slide` should be /aɪ/ rather than /ʌɪ/