### PR TITLE
docs: mention support for scoped packages

### DIFF
--- a/themes/use.md
+++ b/themes/use.md
@@ -8,6 +8,9 @@ theme: seriph
 ---
 ```
 
+> **Note**
+> To install a theme from a scoped package, you will have to give the full namespace e.g `@organization/slidev-theme-name`
+
 You can start the server, which will prompt you to install the theme automatically
 
 <div class="language-md">


### PR DESCRIPTION
It could be handy to mention [support for themes from scoped packages](https://github.com/slidevjs/slidev/pull/604)  in the docs