### PR TITLE
docs: remove unnecessary colons

### DIFF
--- a/builtin/layouts.md
+++ b/builtin/layouts.md
@@ -190,7 +190,7 @@ layout: two-cols-header
 
 This spans both
 
-:::left:::
+::left::
 
 # Left
 


### PR DESCRIPTION
Unnecessary colons were added, so the display was not as intended.

|Before|After|
|---|---|
|![CleanShot 2023-09-01 at 05 03 05](https://github.com/slidevjs/docs/assets/11070996/2aee9b00-c9fa-4337-af94-594a7c751493)|![CleanShot 2023-09-01 at 05 03 21](https://github.com/slidevjs/docs/assets/11070996/6fea3cc8-fac2-4cc4-9595-ab306693e9b2)|

