### PR TITLE
docs: update hosting guide for GitHub Pages

### DIFF
--- a/guide/hosting.md
+++ b/guide/hosting.md
@@ -195,5 +195,5 @@ jobs:
         id: deployment
         uses: actions/deploy-pages@v2
 ```
-- In your repository, go to Settings>Pages. Under "Build and deployment", select "Deploy from a branch", select "gh-pages" and "root". Click on save.
+- In your repository, go to Settings>Pages. Under "Build and deployment", select "Github Actions".
 - Finally, after all workflows are executed, a link to the slides should appear under Settings>Pages.


### PR DESCRIPTION
Update setup of deployment to GitHub pages. This was commented to work (and the action actually asked for it in my case) [here](https://github.com/actions/configure-pages/issues/40#issuecomment-1407442477).