### PR TITLE
docs: call out required leading slash in base path

### DIFF
--- a/guide/hosting.md
+++ b/guide/hosting.md
@@ -139,7 +139,7 @@ Create `vercel.json` in your project root with the following content.
 
 Then go to your Vercel dashboard and create a new site with the repository.
 
-## GitHub Pages
+### GitHub Pages
 
 - [GitHub Pages](https://pages.github.com/)
 

--- a/guide/hosting.md
+++ b/guide/hosting.md
@@ -17,7 +17,7 @@ Then you can host it on [GitHub Pages](https://pages.github.com/), [Netlify](htt
 
 ### Base Path
 
-To deploy your slides under sub-routes, you will need to pass the `--base` option. The `--base` path **must** start with a leading slash; for example:
+To deploy your slides under sub-routes, you will need to pass the `--base` option. The `--base` path **must begin and end** with a slash `/`; for example:
 
 ```bash
 $ slidev build --base /talks/my-cool-talk/
@@ -145,7 +145,7 @@ Then go to your Vercel dashboard and create a new site with the repository.
 
 To deploy your slides on GitHub Pages:
 - upload all the files of the project in your repo (i.e. named `name_of_repo`)
-- create `.github/workflows/deploy.yml` with following content to deploy your slides to GitHub Pages via GitHub Actions. In this file, replace `<name_of_repo>` with `name_of_repo`. Make sure to leave the leading slash in place.
+- create `.github/workflows/deploy.yml` with following content to deploy your slides to GitHub Pages via GitHub Actions. In this file, replace `<name_of_repo>` with `name_of_repo`. Make sure to leave the leading and trailing slashes in place.
 
 ```yaml
 name: Deploy pages
@@ -183,7 +183,7 @@ jobs:
         run:  npm i -g @slidev/cli
 
       - name: Build
-        run: slidev build --base /<name_of_repo>
+        run: slidev build --base /<name_of_repo>/
 
       - uses: actions/configure-pages@v3
 

--- a/guide/hosting.md
+++ b/guide/hosting.md
@@ -17,7 +17,7 @@ Then you can host it on [GitHub Pages](https://pages.github.com/), [Netlify](htt
 
 ### Base Path
 
-To deploy your slides under sub-routes, you will need to pass the `--base` option. For example:
+To deploy your slides under sub-routes, you will need to pass the `--base` option. The `--base` path **must** start with a leading slash; for example:
 
 ```bash
 $ slidev build --base /talks/my-cool-talk/
@@ -145,7 +145,7 @@ Then go to your Vercel dashboard and create a new site with the repository.
 
 To deploy your slides on GitHub Pages:
 - upload all the files of the project in your repo (i.e. named `name_of_repo`)
-- create `.github/workflows/deploy.yml` with following content to deploy your slides to GitHub Pages via GitHub Actions. In this file, replace `<name_of_repo>` with `name_of_repo`.
+- create `.github/workflows/deploy.yml` with following content to deploy your slides to GitHub Pages via GitHub Actions. In this file, replace `<name_of_repo>` with `name_of_repo`. Make sure to leave the leading slash in place.
 
 ```yaml
 name: Deploy pages
@@ -183,7 +183,7 @@ jobs:
         run:  npm i -g @slidev/cli
 
       - name: Build
-        run: slidev build --base <name_of_repo>
+        run: slidev build --base /<name_of_repo>
 
       - uses: actions/configure-pages@v3
 


### PR DESCRIPTION
When deploying to GitHub Pages, you must provide the `--base` path to the build in order to properly transform the asset paths.

The docs fail to mention that the `--base` path **must begin and end** with a slash `/{base path}/`. This information _is_ surfaced as a warning in the CLI.

```shell
$ slidev build --base my-repo

(!) "base" option should start with a slash.
```

I would imagine this requirement should be added to the other static hosting options; however, I've only tested with GitHub pages.