### PR TITLE
fix: Remove extra space for props to be parsed correctly

### DIFF
--- a/guide/syntax.md
+++ b/guide/syntax.md
@@ -119,7 +119,7 @@ function add(
 You can enable line number to all slides by setting `lineNumbers: true` on the config or enable each code block individually by setting `lines:true`. In case you want to disable the numbering for an specific block when `lineNumbers: true` you can set `lines:false` for that block:
 
 ~~~ts
-//```ts {2,3} {lines:true}
+//```ts {2,3}{lines:true}
 function add(
   a: Ref<number> | number,
   b: Ref<number> | number
@@ -132,7 +132,7 @@ function add(
 You can also set the starting line for each code block and highlight the lines accordingly, defaults to 1:
 
 ~~~ts
-//```ts {6,7} {lines:true, startLine:5}
+//```ts {6,7}{lines:true, startLine:5}
 function add(
   a: Ref<number> | number,
   b: Ref<number> | number
@@ -160,7 +160,7 @@ This will first highlight `a: Ref<number> | number` and `b: Ref<number> | number
 You can start the highlight at a specific click:
 
 ~~~ts
-//```ts {2-3|5|all} {at:0}
+//```ts {2-3|5|all}{at:0}
 function add(
   a: Ref<number> | number,
   b: Ref<number> | number
@@ -189,7 +189,7 @@ If the code doesn't fit into one slide, you can pass an extra maxHeight option w
 and enable scrolling
 
 ~~~ts {2|3|7|12}
-//```ts {2|3|7|12} {maxHeight:'100px'}
+//```ts {2|3|7|12}{maxHeight:'100px'}
 function add(
   a: Ref<number> | number,
   b: Ref<number> | number


### PR DESCRIPTION
Remove extra space after the regex syntax change

https://github.com/slidevjs/slidev/commit/80be226b201f68f67af8e82d3594558a50c29251#diff-345d7ee55c0f3c8202375b28cf816e5fdf5f246d760624b86ed2e6f22c1510f1R192

Related: https://github.com/slidevjs/slidev/issues/1246#issuecomment-1902759691

