### PR TITLE
fix: components not found (#165)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -33,9 +33,7 @@ export default defineConfig({
         './.vitepress/@slidev/client/builtin',
       ],
       extensions: ['vue', 'md'],
-      include: [
-        /\.(vue|md)$/,
-      ],
+      include: [/\.vue$/, /\.vue\?vue/, /\.md$/],
       resolvers: [
         IconsResolver({
           prefix: '',


### PR DESCRIPTION
fix #165
fix https://github.com/slidevjs/slidev/issues/1284

Previously, some components are not automatically imported by `unplugin-vue-components`, which caused the above issue.