### PR TITLE
docs: added info about the possibility to start YouTube video at specific time

### DIFF
--- a/builtin/components.md
+++ b/builtin/components.md
@@ -262,6 +262,8 @@ Parameters:
 * `width` (`number`): width of the video
 * `height` (`number`): height of the video
 
+You can also make the video start at specific time if you add `?start=1234` to the id value (where 1234 are seconds),
+
 ## Custom Components
 
 Create a directory `components/` under your project root, and simply put your custom Vue components under it, then you can use it with the same name in your markdown file!


### PR DESCRIPTION
ID can be extended with ?time=1234 and then the video starts at 1234 seconds.

Could also be a new prop in the future, but as id prop is already string we can perhaps just use it like suggested and don't introduce breaking changes if somebody already figured this out(?).