### PR TITLE
docs: fix typo in syntax.md

### DIFF
--- a/guide/syntax.md
+++ b/guide/syntax.md
@@ -646,7 +646,7 @@ src: ./content.md
 
 > Available since v0.43.0
 
-Slidev has and experimental support for [MDC (Markdown Components) Syntax](https://content.nuxtjs.org/guide/writing/mdc) powered by [`markdown-it-mdc`](https://github.com/antfu/markdown-it-mdc).
+Slidev has an experimental support for [MDC (Markdown Components) Syntax](https://content.nuxtjs.org/guide/writing/mdc) powered by [`markdown-it-mdc`](https://github.com/antfu/markdown-it-mdc).
 
 You can enable it by add `mdc: true` to the frontmatter of your markdown file.
 

--- a/guide/syntax.md
+++ b/guide/syntax.md
@@ -648,7 +648,7 @@ src: ./content.md
 
 Slidev has an experimental support for [MDC (Markdown Components) Syntax](https://content.nuxtjs.org/guide/writing/mdc) powered by [`markdown-it-mdc`](https://github.com/antfu/markdown-it-mdc).
 
-You can enable it by add `mdc: true` to the frontmatter of your markdown file.
+You can enable it by adding `mdc: true` to the frontmatter of your markdown file.
 
 ```md
 ---


### PR DESCRIPTION
Fixed a typo by replacing "and" by "an"