### PR TITLE
feat: Add guide to adding svg images

### DIFF
--- a/guide/syntax.md
+++ b/guide/syntax.md
@@ -316,6 +316,12 @@ For local assets, put them into the [`public` folder](/custom/directory-structur
 ![Local Image](/pic.png)
 ```
 
+In the case want to include an **SVG image** you need to add `?skipsvgo` to the image path.
+
+```md
+![Local Image](/pic.svg?skipsvgo)
+```
+
 For you want to apply custom sizes or styles, you can convert them to the `<img>` tag
 
 ```html


### PR DESCRIPTION
I stumbled to add svg images to my slides.
This caused build

Vue-svg was getting into my way so I decided to update the docs to help the struggling souls of the future

https://www.npmjs.com/package/vite-svg-loader#skip-svgo-for-a-single-file