### PR TITLE
docs: fix typo in fonts.md

### DIFF
--- a/custom/fonts.md
+++ b/custom/fonts.md
@@ -86,7 +86,7 @@ If you want to disable the fallback fonts, configure as following
 ---
 fonts:
   mono: 'Fira Code, monospace'
-  fallback: false
+  fallbacks: false
 ---
 ```
 


### PR DESCRIPTION
The correct name should be `fallbacks`.