### PR TITLE
fix: home page link buttons style

### DIFF
--- a/index.md
+++ b/index.md
@@ -1,5 +1,6 @@
 ---
 layout: home
+markdownStyles: false
 ---
 
 <LandingPage />


### PR DESCRIPTION
The reason causes the problem is [here](https://github.com/vuejs/vitepress/blob/main/CHANGELOG.md#breaking-changes)

And you also can see the solution in [vitepress's](https://vitepress.dev/reference/default-theme-home-page#layout) website.
![image](https://github.com/slidevjs/docs/assets/82451257/fd0d5597-780f-4fe1-8493-971fe0dfc300)


before:
![image](https://github.com/slidevjs/docs/assets/82451257/db91d7b6-4cdf-49e5-b8ff-259d788d339a)

after:
![image](https://github.com/slidevjs/docs/assets/82451257/e8c8d4d0-9221-4774-972c-fffac6d5ebe7)
