### PR TITLE
chore: typo

### DIFF
--- a/custom/highlighters.md
+++ b/custom/highlighters.md
@@ -7,7 +7,7 @@ Slidev comes with two syntax highlighters for you to choose from:
 
 **Prism** is one of the most popular syntax highlighters. The highlighting is done by adding token classes to the code and it's colored using CSS. You can browse through their [official themes](https://github.com/PrismJS/prism-themes), or create/customize one yourself very easily using [`prism-theme-vars`](https://github.com/antfu/prism-theme-vars).
 
-**Shiki** is a TextMate grammar-powered syntax highlighter. It generates colored tokens, so there is no additional CSS needed. Since it has great grammar support, the generated colors are very accurate, just like what you will see in VS Code. Shiki also comes with [a bunch of built-in themes](https://shiki.style/themes). In Slidev, we also provided the [TwoSlash](#twoslash-integration) support is also built-in.
+**Shiki** is a TextMate grammar-powered syntax highlighter. It generates colored tokens, so there is no additional CSS needed. Since it has great grammar support, the generated colors are very accurate, just like what you will see in VS Code. Shiki also comes with [a bunch of built-in themes](https://shiki.style/themes). In Slidev, [TwoSlash](https://sli.dev/guide/syntax#twoslash-integration) support is also built-in.
 
 Slidev themes usually support both Prism and Shiki, but depending on the theme you are using, it might only support one of them.
 


### PR DESCRIPTION
There was a dead link referring to TwoSlash support. The link now refers to an appropriate part of the docs:

[https://sli.dev/guide/syntax#twoslash-integration](https://sli.dev/guide/syntax#twoslash-integration)

I also fixed a minor issue with confusing wording on the same line.